### PR TITLE
fix: avoid writing new empty lines on windows

### DIFF
--- a/src/trove_setup/app.py
+++ b/src/trove_setup/app.py
@@ -171,6 +171,7 @@ class TroveSetupApp(App[t.List[str]]):
         ).absolute()
 
         with self.pyproject_path.open(mode="rb") as f:
+
             self.pyproject = tomlkit.load(f)
 
         if type_ == TConfigType.auto:
@@ -297,8 +298,13 @@ class TroveSetupApp(App[t.List[str]]):
                 tomlkit.array("[" + ",".join(array_items_str) + "]").multiline(True)
             )
 
-            with open(self.pyproject_path, "w") as f:
-                tomlkit.dump(self.pyproject, f)
+            # Above reads bytes but writes string, turning \r\n into double lines
+            # with open(self.pyproject_path, "w") as f:
+            #     tomlkit.dump(self.pyproject, f)
+            #
+            out = tomlkit.dumps(self.pyproject)
+            self.pyproject_path.write_bytes(out.encode("utf-8"))
+
             self.exit(
                 result=self.read_classifiers(),
                 message=f"New classifiers written to {str(self.pyproject_path)}",

--- a/src/trove_setup/app.py
+++ b/src/trove_setup/app.py
@@ -297,10 +297,6 @@ class TroveSetupApp(App[t.List[str]]):
                 tomlkit.array("[" + ",".join(array_items_str) + "]").multiline(True)
             )
 
-            # Above reads bytes but writes string, turning \r\n into double lines
-            # with open(self.pyproject_path, "w") as f:
-            #     tomlkit.dump(self.pyproject, f)
-            #
             out = tomlkit.dumps(self.pyproject)
             self.pyproject_path.write_bytes(out.encode("utf-8"))
 

--- a/src/trove_setup/app.py
+++ b/src/trove_setup/app.py
@@ -171,7 +171,6 @@ class TroveSetupApp(App[t.List[str]]):
         ).absolute()
 
         with self.pyproject_path.open(mode="rb") as f:
-
             self.pyproject = tomlkit.load(f)
 
         if type_ == TConfigType.auto:


### PR DESCRIPTION
App as was was not cross platform, it read \r\n and wrote out blank lines between each line, oddly not between the trove classifiers.

This now works on Windows. It should work on any other system because there shouldn't be any transparent conversion of line breaks by tomlkit now.

Tests are still chugging along on my machine, but they haven't failed yet.

Thanks